### PR TITLE
fixed bug in layout_stress.R (Issue #71)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: graphlayouts
 Title: Additional Layout Algorithms for Network Visualizations
-Version: 1.0.1
+Version: 1.0.1.1
 Authors@R: person("David", "Schoch", email = "david@schochastics.net", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2952-4812"))
 Description: Several new layout algorithms to visualize networks are provided which are not part of 'igraph'. 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: graphlayouts
 Title: Additional Layout Algorithms for Network Visualizations
-Version: 1.0.1.1
+Version: 1.0.1.9000
 Authors@R: person("David", "Schoch", email = "david@schochastics.net", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2952-4812"))
 Description: Several new layout algorithms to visualize networks are provided which are not part of 'igraph'. 

--- a/R/layout_stress.R
+++ b/R/layout_stress.R
@@ -50,9 +50,15 @@ layout_with_stress <- function(g, weights = NA, iter = 500, tol = 0.0001, mds = 
   if (comps$no > 1) {
     lg <- list()
     node_order <- c()
+    if (!is.null(weights) && any(!is.na(weights))) {
+      igraph::edge_attr(g, '_edgename') <- 1:igraph::ecount(g)
+      names(weights) <- 1:igraph::ecount(g)
+    }
+
     for (i in 1:comps$no) {
       idx <- comps$membership == i
       sg <- igraph::induced_subgraph(g, idx)
+      edge_idx <- igraph::edge_attr(g, '_edgename') %in% igraph::edge_attr(sg, '_edgename')
       n <- igraph::vcount(sg)
       node_order <- c(node_order, which(idx))
       if (n == 1) {
@@ -64,7 +70,7 @@ layout_with_stress <- function(g, weights = NA, iter = 500, tol = 0.0001, mds = 
         next()
       }
       if (!is.null(weights) && any(!is.na(weights))) {
-        D <- igraph::distances(sg, weights = weights[idx])
+        D <- igraph::distances(sg, weights = weights[edge_idx])
       } else {
         D <- igraph::distances(sg, weights = weights)
       }
@@ -159,9 +165,14 @@ layout_with_stress3D <- function(g, weights = NA, iter = 500, tol = 0.0001, mds 
   if (comps$no > 1) {
     lg <- list()
     node_order <- c()
+    if (!is.null(weights) && any(!is.na(weights))) {
+      igraph::edge_attr(g, '_edgename') <- 1:igraph::ecount(g)
+      names(weights) <- 1:igraph::ecount(g)
+    }
     for (i in 1:comps$no) {
       idx <- comps$membership == i
       sg <- igraph::induced_subgraph(g, idx)
+      edge_idx <- igraph::edge_attr(g, '_edgename') %in% igraph::edge_attr(sg, '_edgename')
       n <- igraph::vcount(sg)
       node_order <- c(node_order, which(idx))
       if (n == 1) {
@@ -174,7 +185,7 @@ layout_with_stress3D <- function(g, weights = NA, iter = 500, tol = 0.0001, mds 
       }
 
       if (!is.null(weights) && any(!is.na(weights))) {
-        D <- igraph::distances(sg, weights = weights[idx])
+        D <- igraph::distances(sg, weights = weights[edge_idx])
       } else {
         D <- igraph::distances(sg, weights = weights)
       }

--- a/tests/testthat/test-stress_majorization.R
+++ b/tests/testthat/test-stress_majorization.R
@@ -1,3 +1,18 @@
+test_that("it works on directed graph with 2 components, in the presence of weights", {
+  adj <- matrix(c(0,2,0,0,0,
+                  0,0,0,0,0,
+                  0,0,0,3,1,
+                  0,0,1,0,1,
+                  0,0,0,0,0),
+                nrow=5)
+  g <- igraph::graph_from_adjacency_matrix(adj, weighted = TRUE)
+  expect_silent(
+    r <- layout_with_stress(g, weights = igraph::E(g)$weight)
+  )
+  expect_is(r, "matrix")
+})
+
+
 test_that("it works on directed connected graph", {
   g <- igraph::make_graph( ~ a -+ b +-+ c -+ d:e:f)
   expect_silent(
@@ -60,6 +75,20 @@ test_that("it works on an undirected graph of two connected dyads with 5 isolate
 
 
 context("Test layout_with_stress3D() on connected graphs")
+
+test_that("that works on directed graph with 2 components, in the presence of weights", {
+  adj <- matrix(c(0,2,0,0,0,
+                  0,0,0,0,0,
+                  0,0,0,3,1,
+                  0,0,1,0,1,
+                  0,0,0,0,0),
+                nrow=5)
+  g <- igraph::graph_from_adjacency_matrix(adj, weighted = TRUE)
+  expect_silent(
+    r <- layout_with_stress3D(g, weights = igraph::E(g)$weight)
+  )
+  expect_is(r, "matrix")
+})
 
 test_that("it works on directed connected graph", {
   g <- igraph::make_graph( ~ a -+ b +-+ c -+ d:e:f)


### PR DESCRIPTION
This PR addresses Issue #71 .

A bug in functions 'layout_stress' and 'layout_stress3D' gives an error when dealing with weighted disconnected graphs when components have more than 2 nodes.

Here is a minimal reproducible example:

`adj <- matrix(c(0,2,0,0,0,
                  0,0,0,0,0,
                  0,0,0,3,1,
                  0,0,1,0,1,
                  0,0,0,0,0),
                nrow=5)
g <- igraph::graph_from_adjacency_matrix(adj, weighted = TRUE) r <- layout_with_stress(g, weights = igraph::E(g)$weight) r3D <- layout_with_stress3D(g, weights = igraph::E(g)$weight) `

The error comes from a bug found at line 67 and 177 in file layout_stress.R. The issue is that the weights of subgraph `sg` are filtered using `idx`, which is a node-based index and not an edge-based index. The problem can be solved by creating an index for edges to keep track of which edges belong to which subgraph. This new index can then be used to select the weights that belong to the edges of the given subgraph.

- Added a new index as an edge attribute when a weighted layout is requested.
- Used the new index to prune edge weights based on which edges present in each subgraph
- Created two new tests for layout_with_stress and layout_with_stress3D.
- Increased version number  1.0.1 -> 1.0.1.1